### PR TITLE
Remove unused error declarations in AquaApp

### DIFF
--- a/src/AquaApp.sol
+++ b/src/AquaApp.sol
@@ -15,7 +15,6 @@ import { TransientLock, TransientLockLib } from "./libs/TransientLock.sol";
 abstract contract AquaApp {
     using TransientLockLib for TransientLock;
 
-    error InvalidAquaStrategy(address maker, bytes32 strategyHash, bytes32 salt, address app, address actualThis);
     error MissingTakerAquaPush(address token, uint256 newBalance, uint256 expectedBalance);
     error MissingNonReentrantModifier();
 

--- a/src/libs/TransientLock.sol
+++ b/src/libs/TransientLock.sol
@@ -18,7 +18,7 @@ library TransientLockLib {
 
     uint256 constant private _UNLOCKED = 0;
     uint256 constant private _LOCKED = 1;
-
+    
     function lock(TransientLock storage self) internal {
         require(self._raw.inc() == _LOCKED, UnexpectedLock());
     }


### PR DESCRIPTION
## Summary

This PR removes the declaration of the InvalidAquaStrategy custom error from the AquaApp.sol abstract contract.

## Details

The error was declared but is not utilized (not triggered by any require or revert) within the base AquaApp contract's functions.
