### PR TITLE
feat: add default Cursor Cloud Agent skills (Jira tasks, 1inch PR template, conventional commits)

### DIFF
--- a/cloud-agent-skills/1inch-pr-template/SKILL.md
+++ b/cloud-agent-skills/1inch-pr-template/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: 1inch-pr-template
+description: "Format every pull request according to 1inch organization standards. Use this skill every time you create or update a pull request: fetch the latest PR template from the 1inch/.github repository for the PR body, include a link to the related Jira ticket, and write the PR title in Conventional Commits format with the Jira ticket key in parentheses in the scope."
+---
+
+# 1inch PR Template and Title Format
+
+## When to Use
+
+**MANDATORY:** Apply this skill every time you create or update a pull request in any 1inch repository.
+
+## PR Body: Always Use the Org Template from `1inch/.github`
+
+The canonical PR template lives in the `1inch/.github` repository and **can change over time — always fetch the current version, never rely on a cached or memorized copy.**
+
+1. Fetch the latest template:
+
+```bash
+gh api repos/1inch/.github/contents/pull_request_template.md --jq '.content' | base64 -d
+```
+
+   If that file is not found, list the repo to locate it (it may move, e.g. into `.github/PULL_REQUEST_TEMPLATE/`):
+
+```bash
+gh api repos/1inch/.github/contents/ --jq '.[].path'
+```
+
+2. Fill in **every section** of the template:
+   - **Change Summary** — 1–2 sentences describing what the PR changes.
+   - **Related Issue/Ticket** — REQUIRED: the Jira ticket key as a markdown link to Jira, e.g. `[PT9-123](https://1inch.atlassian.net/browse/PT9-123)`. The ticket comes from the `jira-task-for-pr` skill (or from a ticket the user provided). Never leave this section empty or as a bare key without the link.
+   - **Testing & Verification** — check the boxes that apply and describe how the change was tested.
+   - **Risk Assessment** — check exactly one risk level and describe risks/impact honestly.
+3. If the repository itself has its own PR template, the org template from `1inch/.github` still takes precedence per this policy — use the org template.
+
+## PR Title: Conventional Commits with Ticket in Parentheses
+
+The PR title MUST follow Conventional Commits, with the Jira ticket key in parentheses as the scope:
+
+```
+<type>(<TICKET-KEY>): <short imperative description>
+```
+
+Examples:
+
+- `feat(PT9-123): add limit order cancellation endpoint`
+- `fix(PT9-456): handle zero-amount swaps in quote calculation`
+- `chore(PT9-789): bump foundry and prettier versions`
+
+Rules:
+
+- `type` is one of: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `build`, `ci`, `style`, `revert`.
+- The scope in parentheses is the Jira ticket key (e.g. `PT9-123`), uppercase, exactly as in Jira.
+- Description is lowercase, imperative mood, no trailing period.
+- Use `!` before the colon for breaking changes, e.g. `feat(PT9-123)!: ...`.

--- a/cloud-agent-skills/README.md
+++ b/cloud-agent-skills/README.md
@@ -1,0 +1,29 @@
+# Default Skills for Cursor Cloud Agents
+
+Three user-level skills that apply to all repositories (not repo-specific):
+
+| Skill | Purpose |
+| --- | --- |
+| `jira-task-for-pr` | Create a Jira task for every PR (PT9 for backend by default), link related epics, assign to you, In Progress → In Review |
+| `1inch-pr-template` | Always use the latest PR template from `1inch/.github`, link the Jira ticket, conventional-commits PR title with ticket in `()` |
+| `conventional-commits` | All commit messages follow the Conventional Commits spec |
+
+## Installation as default skills
+
+Cursor discovers user-level skills from `~/.cursor/skills/<skill-name>/SKILL.md` (see [cursor.com/docs/skills](https://cursor.com/docs/skills)). Cloud Agents run on fresh VMs, so the skills must be provisioned into the VM's home directory via your **personal (or team) saved cloud-agent environment** — that's what makes them apply by default across all repos.
+
+Add this to your cloud-agent environment install/start script (or Dockerfile), replacing the copy source with wherever you host these files (e.g. a small git repo or gist):
+
+```bash
+mkdir -p ~/.cursor/skills
+cp -r /path/to/cloud-agent-skills/jira-task-for-pr ~/.cursor/skills/
+cp -r /path/to/cloud-agent-skills/1inch-pr-template ~/.cursor/skills/
+cp -r /path/to/cloud-agent-skills/conventional-commits ~/.cursor/skills/
+```
+
+For local Cursor (IDE/CLI), simply copy the three folders into `~/.cursor/skills/` on your machine.
+
+Notes:
+
+- The `jira-task-for-pr` skill requires the Atlassian MCP server to be available to the agent (it already is in this environment).
+- The `1inch-pr-template` skill requires `gh` CLI read access to `1inch/.github` (available to Cloud Agents by default).

--- a/cloud-agent-skills/conventional-commits/SKILL.md
+++ b/cloud-agent-skills/conventional-commits/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: conventional-commits
+description: "Write all git commit messages using the Conventional Commits specification. Use this skill every time you create a git commit, in any repository: choose the right type (feat, fix, chore, refactor, etc.), an optional scope, and a concise imperative subject line."
+---
+
+# Conventional Commits
+
+## When to Use
+
+**MANDATORY:** Apply this skill for every `git commit` you create.
+
+## Format
+
+```
+<type>(<optional scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Types
+
+| Type | Use for |
+| --- | --- |
+| `feat` | A new feature |
+| `fix` | A bug fix |
+| `docs` | Documentation-only changes |
+| `style` | Formatting, whitespace, missing semicolons (no code behavior change) |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `perf` | Performance improvement |
+| `test` | Adding or correcting tests |
+| `build` | Build system or external dependency changes |
+| `ci` | CI configuration and scripts |
+| `chore` | Other maintenance that doesn't modify src or test files |
+| `revert` | Reverting a previous commit |
+
+## Rules
+
+- Subject line: imperative mood ("add", not "added"/"adds"), lowercase after the colon, no trailing period, ideally ≤ 72 characters.
+- Scope is optional; use it for the affected module/area (e.g. `feat(orders): ...`). If a Jira ticket is associated with the work, the ticket key may be used as the scope, consistent with the PR title convention.
+- Breaking changes: append `!` after the type/scope (`feat(api)!: ...`) and/or add a `BREAKING CHANGE:` footer describing the break.
+- Body (optional): explain the what and why, not the how. Separate from the subject with a blank line.
+- One logical change per commit; each commit message must accurately describe its own change.
+
+## Examples
+
+```
+feat(orders): add partial fill support for limit orders
+
+fix(quotes): prevent division by zero when reserves are empty
+
+chore: update yarn lockfile after dependency bump
+
+refactor(PT9-321)!: replace legacy resolver interface
+
+BREAKING CHANGE: IResolver.resolve() now returns a struct instead of a tuple.
+```

--- a/cloud-agent-skills/jira-task-for-pr/SKILL.md
+++ b/cloud-agent-skills/jira-task-for-pr/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: jira-task-for-pr
+description: "Always create and manage a Jira task whenever a pull request is created. Use this skill every time you are about to create a PR, open a PR, push a branch that will become a PR, or finish work on a PR. Creates the Jira task in PT9 for backend work (or a user-specified project), links related epics, assigns the task to the requesting user, moves it to In Progress while working and In Review when the PR is ready."
+---
+
+# Jira Task for Every PR
+
+## When to Use
+
+**MANDATORY:** Apply this skill every time you create a pull request. No PR should exist without a corresponding Jira task. Also apply it at the end of the task, when the PR is finished, to transition the Jira issue.
+
+## Jira Site
+
+All operations use the `1inch.atlassian.net` Jira site (pass it as `cloudId` to Atlassian MCP tools; if that fails, resolve the cloudId via `getAccessibleAtlassianResources`).
+
+## Project Selection
+
+1. **If the user explicitly specified a Jira project or space** (in the task description, a linked issue, or conversation) — use that project. An explicit instruction always wins.
+2. **If the work is backend** (services, APIs, smart-contract backends, infrastructure, databases, workers, anything server-side) — use project **PT9** ("Product Team 9 (Backend)").
+3. **Otherwise** — try to infer the correct project from context (repository name, team conventions, similar recent issues found via JQL). If nothing can be inferred confidently, fall back to **PT9** and mention this in your summary so the user can correct it.
+
+## Workflow
+
+### Step 1: Create the Jira task (before or right after opening the PR)
+
+1. Determine the requesting user's Jira account:
+   - Call `atlassianUserInfo` to get the current user's `accountId`. This is the user the task must be assigned to.
+2. Search for a related Epic to link to:
+   - Run 1–3 JQL searches for open Epics in the target project matching the feature area, e.g.:
+     `searchJiraIssuesUsingJql(cloudId="1inch.atlassian.net", jql='project = PT9 AND issuetype = Epic AND statusCategory != Done AND (summary ~ "<feature keywords>" OR text ~ "<feature keywords>") ORDER BY updated DESC', fields=["summary","status"], maxResults=10)`
+   - Pick the Epic whose scope clearly matches the PR's work. If no Epic clearly matches, create the task without a parent and note that in your summary. Do NOT guess a wrong Epic.
+3. Create the task:
+   - `createJiraIssue` with:
+     - `projectKey`: the project chosen above
+     - `issueTypeName`: `"Task"` (use `"Bug"` if the PR is a pure bug fix)
+     - `summary`: concise description of the change, matching the PR title's meaning
+     - `description`: what is being changed and why, plus a link to the PR (add the PR link with `editJiraIssue` or a comment after the PR exists if you create the issue first)
+     - assignee: the current user's `accountId` (via `additional_fields`: `{"assignee": {"accountId": "<accountId>"}}`)
+     - Epic link/parent: the Epic found in step 2, if any
+   - If assignee or Epic link cannot be set at creation time (field not on the create screen), set them right after with `editJiraIssue`.
+
+### Step 2: Move to In Progress (default status while working)
+
+- Get available transitions with `getTransitionsForJiraIssue`, find the transition to **In Progress** (match case-insensitively), and apply it with `transitionJiraIssue`.
+- Do this immediately after creating the issue.
+
+### Step 3: Reference the ticket everywhere
+
+- Put the issue key in the PR title scope, e.g. `feat(PT9-123): ...` (see the `1inch-pr-template` skill).
+- Include a link to the Jira issue (`https://1inch.atlassian.net/browse/<KEY>`) in the PR description.
+- Add a comment or remote link on the Jira issue pointing to the PR URL.
+
+### Step 4: Move to In Review when finished
+
+- When the PR is pushed and ready (end of the task, PR opened/updated for review), transition the issue to **In Review** using `getTransitionsForJiraIssue` + `transitionJiraIssue`.
+- If a transition named exactly "In Review" does not exist, use the closest equivalent (e.g. "Code Review", "Review"). If no review-like transition exists, leave it In Progress and mention this in your summary.
+
+## Rules
+
+- One Jira task per PR. If the user already provided an existing ticket for this work, do NOT create a duplicate — use the provided ticket, assign it to the user if unassigned, and follow the same status transitions.
+- Always assign the task to the requesting user (from `atlassianUserInfo`), never leave it unassigned and never assign to someone else unless explicitly told to.
+- Always report in your final summary: issue key with URL, project used, Epic linked (or "none found"), and final status.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change Summary
**What does this PR change?**
Adds three prepared user-level skills for Cursor Cloud Agents under `cloud-agent-skills/`, intended to be installed into `~/.cursor/skills/` via the cloud-agent environment so they apply by default across all repos (not just this one). This repo is only used as a delivery vehicle for the files.

- `jira-task-for-pr` — always create a Jira task per PR (PT9 for backend unless another project is specified), search and link related Epics, assign to the requesting user, transition In Progress → In Review.
- `1inch-pr-template` — always fetch the latest PR template from `1inch/.github`, include a Jira ticket link, and use Conventional Commits PR titles with the ticket key in parentheses.
- `conventional-commits` — all commit messages follow the Conventional Commits spec.

**Related Issue/Ticket:**
N/A — tooling/skills preparation, no product change.

## Testing & Verification
**How was this tested?**
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps)
- [ ] Verified on staging

Verified referenced integrations: `PT9` project exists on `1inch.atlassian.net` (name: "Product Team 9 (Backend)"), and the org PR template is fetchable at `1inch/.github/pull_request_template.md` via `gh api`. Skill frontmatter follows the documented SKILL.md format (name matches folder, description present).

## Risk Assessment
**Risk Level:**
- [x] **Low** - Minor changes, no operational impact
- [ ] **Medium** - Moderate changes, limited impact, standard rollback available
- [ ] **High** - Significant changes, potential operational impact, complex rollback

**Risks & Impact**
Documentation/skill files only; no code, build, or deployment changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6a05-4b75-7eb6-8ea3-9a80cad6af32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6a05-4b75-7eb6-8ea3-9a80cad6af32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

