### PR TITLE
docs: update README with canonical Aqua and SwapVM addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,27 +484,16 @@ forge test
 
 ## Deployments
 
-The Aqua Protocol is deployed across multiple networks at the same address:
+Aqua and the SwapVM router are deterministic deployments with the same address on every supported chain. Only interact with these two contracts. Anything else is not Aqua.
 
-**Contract Address:** `0x499943e74fb0ce105688beee8ef2abec5d936d31`
+| Contract | Address |
+|----------|---------|
+| Aqua (registry) | `0x1111113ccf1426a8e30e2bff5e005d929bf6a90a` |
+| SwapVM router | `0x111111338c5091e8440b67b168bae16a668ac0de` |
 
 ### Supported Networks
 
-| Network | Contract Address |
-|---------|-----------------|
-| Ethereum Mainnet | `0x499943e74fb0ce105688beee8ef2abec5d936d31` |
-| Base | `0x499943e74fb0ce105688beee8ef2abec5d936d31` |
-| Optimism | `0x499943e74fb0ce105688beee8ef2abec5d936d31` |
-| Polygon | `0x499943e74fb0ce105688beee8ef2abec5d936d31` |
-| Arbitrum | `0x499943e74fb0ce105688beee8ef2abec5d936d31` |
-| Avalanche | `0x499943e74fb0ce105688beee8ef2abec5d936d31` |
-| Binance Smart Chain | `0x499943e74fb0ce105688beee8ef2abec5d936d31` |
-| Linea | `0x499943e74fb0ce105688beee8ef2abec5d936d31` |
-| Sonic | `0x499943e74fb0ce105688beee8ef2abec5d936d31` |
-| Unichain | `0x499943e74fb0ce105688beee8ef2abec5d936d31` |
-| Gnosis | `0x499943e74fb0ce105688beee8ef2abec5d936d31` |
-| zkSync | `0x499943e74fb0ce105688beee8ef2abec5d936d31` |
-| Robinhood | `0x7c2d4aa5c900c08004fadb1c0d953c5b099fec86` |
+Ethereum Mainnet, Base, Optimism, Polygon, Arbitrum, Avalanche, Binance Smart Chain, Linea, Sonic, Unichain, Gnosis, zkSync, Robinhood
 
 
 ## License


### PR DESCRIPTION
## Summary
- Replace the superseded Aqua registry address (`0x4999…6d31`) in the README Deployments section with the current vanity deployments
- Document both canonical contracts used by integrators: Aqua (registry) and SwapVM router
- Note that Robinhood now shares the same universal addresses (no longer a CREATE3 outlier)

Addresses (same on every supported chain), verified against [Aqua Learn — For resolvers](https://1inch.com/aqua/learn/resolvers) and the [Business portal Aqua changelog](https://business.1inch.com/portal/documentation/aqua/overview/changelog) (manifest `2026-07-29`):

| Contract | Address |
|----------|---------|
| Aqua (registry) | `0x1111113ccf1426a8e30e2bff5e005d929bf6a90a` |
| SwapVM router | `0x111111338c5091e8440b67b168bae16a668ac0de` |

## Test plan
- [ ] Confirm README Deployments section renders correctly on GitHub
- [ ] Spot-check the two addresses against the Learn resolvers page and Business portal changelog
- [ ] Confirm Robinhood is listed without a distinct address


Made with [Cursor](https://cursor.com)